### PR TITLE
Flag .blp files as binary for git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.blp binary


### PR DESCRIPTION
My default line endings are LF. Git wanted to change `format/blp/testdata/test6.BLP` from CRLF -> LF, but it's binary.